### PR TITLE
tighten 'restore active sleep' condition

### DIFF
--- a/frontend/src/Components/07-Modal/Modal.js
+++ b/frontend/src/Components/07-Modal/Modal.js
@@ -16,7 +16,7 @@ export default function SleepModal({ id }) {
 
   useEffect(() => {
     // restore active sleep session if user logs out
-    if (currSleep && currSleep.creator === id) {
+    if (currSleep) {
       if (currSleep.sleepStart && !currSleep.sleepEnd) {
         setData((prev) => Object.assign(prev, currSleep));
         setIsSleeping(true);


### PR DESCRIPTION
- restoring active sleep sessions on re-log is much easier if sleep data is cleared from state => useEffect condition checking the last sleep session can be simpler